### PR TITLE
Convert lessons and themes nodes to Relay Connections

### DIFF
--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GraphQL;
 using GraphQL.Types;
+using GraphQL.Types.Relay.DataObjects;
 using TeacherWorkout.Api.GraphQL.Types;
 using TeacherWorkout.Api.Models;
 
@@ -13,14 +14,15 @@ namespace TeacherWorkout.Api.GraphQL
         public TeacherWorkoutQuery()
         {
             Name = "Query";
-            
-            Field<ListGraphType<NonNullGraphType<ThemeType>>>(
-                "themes",
-                resolve: context =>
+         
+            Connection<NonNullGraphType<ThemeType>>()
+                .Name("themes")
+                .Bidirectional()
+                .Resolve(context =>
                 {
-                    return new[]
+                    var themes = new List<Theme>
                     {
-                        new Theme
+                        new()
                         {
                             Id = "1",
                             Title = "Lorem Ipsum",
@@ -29,6 +31,24 @@ namespace TeacherWorkout.Api.GraphQL
                                 Description = "Cat Photo",
                                 Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
                             }
+                        }
+                    };
+
+                    var edges = themes.Select(e => new Edge<Theme>
+                    {
+                        Cursor = e.Id,
+                        Node = e
+                    }).ToList();
+                    
+                    return new Connection<Theme>
+                    {
+                        Edges = edges,
+                        PageInfo = new PageInfo
+                        {
+                            StartCursor = edges.FirstOrDefault()?.Cursor,
+                            EndCursor = edges.LastOrDefault()?.Cursor,
+                            HasPreviousPage = false,
+                            HasNextPage = false,
                         }
                     };
                 });

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
@@ -53,14 +53,13 @@ namespace TeacherWorkout.Api.GraphQL
                     };
                 });
             
-            Field<ListGraphType<NonNullGraphType<LessonType>>>(
-                "lessons",
-                arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "themeId", Description = "id of the Theme" }
-                ),
-                resolve: context =>
+            Connection<NonNullGraphType<LessonType>>()
+                .Name("lessons")
+                .Argument<NonNullGraphType<IdGraphType>>("themeId", "id of the Theme")
+                .ReturnAll()
+                .Resolve(context =>
                 {
-                    return new[]
+                    var lessons = new[]
                     {
                         new Lesson
                         {
@@ -87,6 +86,24 @@ namespace TeacherWorkout.Api.GraphQL
                                 Value = 45,
                                 Unit = DurationUnit.Minutes
                             }
+                        }
+                    };
+                    
+                    var edges = lessons.Select(e => new Edge<Lesson>
+                    {
+                        Cursor = e.Id,
+                        Node = e
+                    }).ToList();
+                    
+                    return new Connection<Lesson>
+                    {
+                        Edges = edges,
+                        PageInfo = new PageInfo
+                        {
+                            StartCursor = edges.FirstOrDefault()?.Cursor,
+                            EndCursor = edges.LastOrDefault()?.Cursor,
+                            HasPreviousPage = false,
+                            HasNextPage = false,
                         }
                     };
                 });

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
@@ -30,6 +30,36 @@ namespace TeacherWorkout.Api.GraphQL
                             Description = "Cat Photo",
                             Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
                         }
+                    },
+                    new()
+                    {
+                        Id = "2",
+                        Title = "Dolor sit amet",
+                        Thumbnail = new Image
+                        {
+                            Description = "Another Cat Photo",
+                            Url = "https://static.toiimg.com/thumb/msid-67586673,width-800,height-600,resizemode-75,imgsize-3918697,pt-32,y_pad-40/67586673.jpg"
+                        }
+                    },
+                    new()
+                    {
+                        Id = "3",
+                        Title = "Consectetur adipiscing elit",
+                        Thumbnail = new Image
+                        {
+                            Description = "YACP",
+                            Url = "http://cdn.shopify.com/s/files/1/1149/5008/articles/why-cat-looking-at-wall-or-nothing.jpg?v=1551321728"
+                        }
+                    },
+                    new()
+                    {
+                        Id = "4",
+                        Title = "Fusce tempor",
+                        Thumbnail = new Image
+                        {
+                            Description = "More Cat Photos",
+                            Url = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcReLDHsAIhgLgFpupyZg0CtevFcI2NY9WkoOQ&usqp=CAU"
+                        }
                     }
                 }.ToConnection());
             

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
@@ -5,6 +5,7 @@ using GraphQL;
 using GraphQL.Types;
 using GraphQL.Types.Relay.DataObjects;
 using TeacherWorkout.Api.GraphQL.Types;
+using TeacherWorkout.Api.GraphQL.Utils;
 using TeacherWorkout.Api.Models;
 
 namespace TeacherWorkout.Api.GraphQL
@@ -18,50 +19,37 @@ namespace TeacherWorkout.Api.GraphQL
             Connection<NonNullGraphType<ThemeType>>()
                 .Name("themes")
                 .Bidirectional()
-                .Resolve(context =>
+                .Resolve(_ => new List<Theme>
                 {
-                    var themes = new List<Theme>
+                    new()
                     {
-                        new()
+                        Id = "1",
+                        Title = "Lorem Ipsum",
+                        Thumbnail = new Image
                         {
-                            Id = "1",
-                            Title = "Lorem Ipsum",
-                            Thumbnail = new Image
-                            {
-                                Description = "Cat Photo",
-                                Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
-                            }
+                            Description = "Cat Photo",
+                            Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
                         }
-                    };
-
-                    var edges = themes.Select(e => new Edge<Theme>
-                    {
-                        Cursor = e.Id,
-                        Node = e
-                    }).ToList();
-                    
-                    return new Connection<Theme>
-                    {
-                        Edges = edges,
-                        PageInfo = new PageInfo
-                        {
-                            StartCursor = edges.FirstOrDefault()?.Cursor,
-                            EndCursor = edges.LastOrDefault()?.Cursor,
-                            HasPreviousPage = false,
-                            HasNextPage = false,
-                        }
-                    };
-                });
+                    }
+                }.ToConnection());
             
             Connection<NonNullGraphType<LessonType>>()
                 .Name("lessons")
                 .Argument<NonNullGraphType<IdGraphType>>("themeId", "id of the Theme")
                 .ReturnAll()
-                .Resolve(context =>
+                .Resolve(_ => new List<Lesson>
                 {
-                    var lessons = new[]
+                    new()
                     {
-                        new Lesson
+                        Id = "1",
+                        Title = "Lorem Ipsum",
+                        Thumbnail = new Image
+                        {
+                            Description = "Cat Photo",
+                            Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
+
+                        },
+                        Theme = new Theme
                         {
                             Id = "1",
                             Title = "Lorem Ipsum",
@@ -69,44 +57,15 @@ namespace TeacherWorkout.Api.GraphQL
                             {
                                 Description = "Cat Photo",
                                 Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
-
-                            },
-                            Theme = new Theme
-                            {
-                                Id = "1",
-                                Title = "Lorem Ipsum",
-                                Thumbnail = new Image
-                                {
-                                    Description = "Cat Photo",
-                                    Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
-                                }
-                            },
-                            Duration = new Duration
-                            {
-                                Value = 45,
-                                Unit = DurationUnit.Minutes
                             }
-                        }
-                    };
-                    
-                    var edges = lessons.Select(e => new Edge<Lesson>
-                    {
-                        Cursor = e.Id,
-                        Node = e
-                    }).ToList();
-                    
-                    return new Connection<Lesson>
-                    {
-                        Edges = edges,
-                        PageInfo = new PageInfo
+                        },
+                        Duration = new Duration
                         {
-                            StartCursor = edges.FirstOrDefault()?.Cursor,
-                            EndCursor = edges.LastOrDefault()?.Cursor,
-                            HasPreviousPage = false,
-                            HasNextPage = false,
+                            Value = 45,
+                            Unit = DurationUnit.Minutes
                         }
-                    };
-                });
+                    }
+                }.ToConnection());
 
             Field<NonNullGraphType<StepUnionType>>(
                 "step",

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
@@ -94,6 +94,81 @@ namespace TeacherWorkout.Api.GraphQL
                             Value = 45,
                             Unit = DurationUnit.Minutes
                         }
+                    },
+                    new()
+                    {
+                        Id = "2",
+                        Title = "Dolor sit amet",
+                        Thumbnail = new Image
+                        {
+                            Description = "Another Cat Photo",
+                            Url = "https://static.toiimg.com/thumb/msid-67586673,width-800,height-600,resizemode-75,imgsize-3918697,pt-32,y_pad-40/67586673.jpg"
+                        },
+                        Theme = new Theme
+                        {
+                            Id = "1",
+                            Title = "Lorem Ipsum",
+                            Thumbnail = new Image
+                            {
+                                Description = "Cat Photo",
+                                Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
+                            }
+                        },
+                        Duration = new Duration
+                        {
+                            Value = 32,
+                            Unit = DurationUnit.Minutes
+                        }
+                    },
+                    new()
+                    {
+                        Id = "3",
+                        Title = "Consectetur adipiscing elit",
+                        Thumbnail = new Image
+                        {
+                            Description = "YACP",
+                            Url = "http://cdn.shopify.com/s/files/1/1149/5008/articles/why-cat-looking-at-wall-or-nothing.jpg?v=1551321728"
+                        },
+                        Theme = new Theme
+                        {
+                            Id = "1",
+                            Title = "Lorem Ipsum",
+                            Thumbnail = new Image
+                            {
+                                Description = "Cat Photo",
+                                Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
+                            }
+                        },
+                        Duration = new Duration
+                        {
+                            Value = 55,
+                            Unit = DurationUnit.Minutes
+                        }
+                    },
+                    new()
+                    {
+                        Id = "4",
+                        Title = "Fusce tempor",
+                        Thumbnail = new Image
+                        {
+                            Description = "More Cat Photos",
+                            Url = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcReLDHsAIhgLgFpupyZg0CtevFcI2NY9WkoOQ&usqp=CAU"
+                        },
+                        Theme = new Theme
+                        {
+                            Id = "1",
+                            Title = "Lorem Ipsum",
+                            Thumbnail = new Image
+                            {
+                                Description = "Cat Photo",
+                                Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/640px-Felis_catus-cat_on_snow.jpg"
+                            }
+                        },
+                        Duration = new Duration
+                        {
+                            Value = 37,
+                            Unit = DurationUnit.Minutes
+                        }
                     }
                 }.ToConnection());
 

--- a/TeacherWorkout.Api/GraphQL/Utils/ConnectionUtils.cs
+++ b/TeacherWorkout.Api/GraphQL/Utils/ConnectionUtils.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Types.Relay.DataObjects;
+using TeacherWorkout.Api.Models;
+
+namespace TeacherWorkout.Api.GraphQL.Utils
+{
+    public static class ConnectionUtils
+    {
+        public static Connection<TSource> ToConnection<TSource>(this IEnumerable<TSource> items) 
+            where TSource: IIdentifiable
+        {
+            var edges = items.Select(e => new Edge<TSource>
+            {
+                Cursor = e.Id,
+                Node = e
+            }).ToList();
+
+            return new Connection<TSource>
+            {
+                Edges = edges,
+                PageInfo = new PageInfo
+                {
+                    StartCursor = edges.FirstOrDefault()?.Cursor,
+                    EndCursor = edges.LastOrDefault()?.Cursor,
+                    HasPreviousPage = false,
+                    HasNextPage = false,
+                }
+            };
+        }
+    }
+}

--- a/TeacherWorkout.Api/Models/Answer.cs
+++ b/TeacherWorkout.Api/Models/Answer.cs
@@ -1,6 +1,6 @@
 namespace TeacherWorkout.Api.Models
 {
-    public class Answer
+    public class Answer : IIdentifiable
     {
         public string Id { get; set; }
         

--- a/TeacherWorkout.Api/Models/IIdentifiable.cs
+++ b/TeacherWorkout.Api/Models/IIdentifiable.cs
@@ -1,0 +1,7 @@
+namespace TeacherWorkout.Api.Models
+{
+    public interface IIdentifiable
+    {
+        public string Id { get; set; }
+    }
+}

--- a/TeacherWorkout.Api/Models/ILessonStep.cs
+++ b/TeacherWorkout.Api/Models/ILessonStep.cs
@@ -1,7 +1,6 @@
 namespace TeacherWorkout.Api.Models
 {
-    public interface ILessonStep
+    public interface ILessonStep : IIdentifiable
     {
-        public string Id { get; set; }
     }
 }

--- a/TeacherWorkout.Api/Models/Lesson.cs
+++ b/TeacherWorkout.Api/Models/Lesson.cs
@@ -1,6 +1,6 @@
 namespace TeacherWorkout.Api.Models
 {
-    public class Lesson
+    public class Lesson : IIdentifiable
     {
         public string Id { get; set; }
 

--- a/TeacherWorkout.Api/Models/Theme.cs
+++ b/TeacherWorkout.Api/Models/Theme.cs
@@ -1,6 +1,6 @@
 namespace TeacherWorkout.Api.Models
 {
-    public class Theme
+    public class Theme : IIdentifiable
     {
         public string Id { get; set; }
 


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
Converts lessons and themes nodes to Relay Connections.
There is no need for another package since we already have support in the official package for Relay connections.

Investigated the relay nuget package and it looks unmaintained and outdated. It was providing only helper functions.

Closes #22 

Bonus: Add more Lessons and Themes as mocked data.

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->
Query:

```
query {
  themes(first: 10, after: "42") {
    totalCount
    pageInfo {
      startCursor
      endCursor
      hasPreviousPage
      hasNextPage
    }
    
    edges {
      cursor
      node {
        id
        title
        thumbnail {
          description
          url
        }
      }
    }
  }
  lessons(themeId: "1", first: 10, after: "42") {
    totalCount
    pageInfo {
      startCursor
      endCursor
      hasPreviousPage
      hasNextPage
    }
    
    edges {
      cursor
      node {
        id
        title
        thumbnail {
          description
          url
        }
      }
    }
  }
}
```