### PR TITLE
Add support for GraphQL Playground

### DIFF
--- a/TeacherWorkout.Api/Startup.cs
+++ b/TeacherWorkout.Api/Startup.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using GraphQL.Server;
 using GraphQL.Types;
 using Microsoft.AspNetCore.Builder;
@@ -35,12 +33,9 @@ namespace TeacherWorkout.Api
                     });
             });
 
-            services.AddControllers();
-
             services.AddSingleton<TeacherWorkoutQuery>();
             services.AddSingleton<TeacherWorkoutMutation>();
             services.AddSingleton<ISchema, TeacherWorkoutSchema>();
-            AddGraphQLNamespaces(services);
 
             services.AddHttpContextAccessor();
             services.AddGraphQL(options =>
@@ -48,7 +43,8 @@ namespace TeacherWorkout.Api
                     options.EnableMetrics = true;
                 })
                 .AddErrorInfoProvider(opt => opt.ExposeExceptionStackTrace = true)
-                .AddSystemTextJson();
+                .AddSystemTextJson()
+                .AddGraphTypes();
 
             services.AddDbContext<TeacherWorkoutContext>(options =>
             options.UseNpgsql(Configuration.GetConnectionString("TeacherWorkoutContext")));
@@ -70,25 +66,10 @@ namespace TeacherWorkout.Api
 
             db.Database.Migrate();
 
-            app.UseGraphQL<ISchema>();
             app.UseRouting();
 
-            app.UseAuthorization();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
-            });
-        }
-
-        private static void AddGraphQLNamespaces(IServiceCollection services)
-        {
-            AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(t => t.GetTypes())
-                .Where(t => t.IsClass)
-                .Where(t => t.Namespace != null && t.Namespace.StartsWith("TeacherWorkout.Api.GraphQL.Types"))
-                .ToList()
-                .ForEach(t => services.AddSingleton(t));
+            app.UseGraphQL<ISchema>();
+            app.UseGraphQLPlayground();
         }
     }
 }

--- a/TeacherWorkout.Api/TeacherWorkout.Api.csproj
+++ b/TeacherWorkout.Api/TeacherWorkout.Api.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="5.0.2" />
+    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="5.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### What does it fix?

This PR adds support for [GraphQL Playground](https://github.com/graphql/graphql-playground) to introspect and play with the existing GraphQL API in the browser.

![image](https://user-images.githubusercontent.com/3010346/129938099-32a27f7f-8ba0-4b2d-9bc9-8f9c036bde75.png)

I've also simplified the `Startup.cs` code by replacing the `AddGraphQLNamespaces` method with the built in `AddGraphTypes` method.

### How has it been tested?

Running the project locally and navigating to `https://localhost:5001/ui/playground`.
