### PR TITLE
[57] singleUpload mutation uploads file to the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,3 +336,10 @@ ASALocalRun/
 # Project specific
 postgres_data
 .env
+
+# VSCode
+.vscode
+
+# MacOS
+.DS_Store
+Thumbs.db

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutMutation.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutMutation.cs
@@ -58,7 +58,7 @@ namespace TeacherWorkout.Api.GraphQL
 
 
             Field<SingleUploadPayloadType>("singleUpload")
-                .Argument<UploadGraphType>(Name = "file")
+                .Argument<NonNullGraphType<UploadGraphType>>(Name = "file")
                 .Resolve(context =>
                 {
                     var file = context.GetArgument<IFormFile>("file");

--- a/TeacherWorkout.Api/GraphQL/Types/Payloads/SingleUploadPayloadType.cs
+++ b/TeacherWorkout.Api/GraphQL/Types/Payloads/SingleUploadPayloadType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using GraphQL.Types;
+using TeacherWorkout.Domain.Models.Payloads;
+
+namespace TeacherWorkout.Api.GraphQL.Types.Payloads
+{
+    public class SingleUploadPayloadType : ObjectGraphType<SingleUploadPayload>
+    {
+        public SingleUploadPayloadType()
+        {
+            Name = "SingleUploadPayload";
+
+            Field(x => x.FileBlobId).Description("The ID of the created file blob.");
+        }
+    }
+}

--- a/TeacherWorkout.Api/Startup.cs
+++ b/TeacherWorkout.Api/Startup.cs
@@ -42,10 +42,12 @@ namespace TeacherWorkout.Api
             AddRepositories(services, "TeacherWorkout.Data");
 
             services.AddHttpContextAccessor();
-            services.AddGraphQL(b => b
-                .AddErrorInfoProvider(opt => opt.ExposeExceptionDetails = true)
-                .AddGraphTypes()
-                .AddSystemTextJson());
+            services
+                .AddGraphQLUpload()
+                .AddGraphQL(b => b
+                    .AddErrorInfoProvider(opt => opt.ExposeExceptionDetails = true)
+                    .AddGraphTypes()
+                    .AddSystemTextJson());
 
             services.AddDbContext<TeacherWorkoutContext>(options =>
                 options.UseNpgsql(Configuration.GetConnectionString("TeacherWorkoutContext")));
@@ -67,7 +69,8 @@ namespace TeacherWorkout.Api
 
             app.UseRouting();
 
-            app.UseGraphQL<ISchema>();
+            app.UseGraphQLUpload<ISchema>()
+                .UseGraphQL<ISchema>();
             app.UseGraphQLGraphiQL();
         }
 

--- a/TeacherWorkout.Api/TeacherWorkout.Api.csproj
+++ b/TeacherWorkout.Api/TeacherWorkout.Api.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="GraphQL.Server.All" Version="7.6.0" />
     <PackageReference Include="GraphQL.Server.Ui.Graphiql" Version="7.6.0" />
+    <PackageReference Include="GraphQL.Upload.AspNetCore" Version="3.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.Designer.cs
+++ b/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherWorkout.Data;
@@ -11,9 +12,11 @@ using TeacherWorkout.Data;
 namespace TeacherWorkout.Data.Migrations
 {
     [DbContext(typeof(TeacherWorkoutContext))]
-    partial class TeacherWorkoutContextModelSnapshot : ModelSnapshot
+    [Migration("20231130130831_AddFileBlobsTable")]
+    partial class AddFileBlobsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.cs
+++ b/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.cs
@@ -23,7 +23,7 @@ namespace TeacherWorkout.Data.Migrations
                     Content = table.Column<byte[]>(type: "bytea", nullable: false),
                     Mimetype = table.Column<string>(type: "text", nullable: false),
                     Description = table.Column<string>(type: "text", nullable: true),
-                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                 },
                 constraints: table =>
                 {

--- a/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.cs
+++ b/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherWorkout.Data.Migrations
+{
+    public partial class AddFileBlobsTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FileBlobId",
+                table: "Images",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "FileBlobs",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    Content = table.Column<byte[]>(type: "bytea", nullable: false),
+                    Mimetype = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FileBlobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Images_FileBlobId",
+                table: "Images",
+                column: "FileBlobId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Images_FileBlobs_FileBlobId",
+                table: "Images",
+                column: "FileBlobId",
+                principalTable: "FileBlobs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Images_FileBlobs_FileBlobId",
+                table: "Images");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Images_FileBlobId",
+                table: "Images");
+
+            migrationBuilder.DropTable(
+                name: "FileBlobs");
+
+            migrationBuilder.DropColumn(
+                name: "FileBlobId",
+                table: "Images");
+        }
+    }
+}

--- a/TeacherWorkout.Data/Repositories/FileBlobRepository.cs
+++ b/TeacherWorkout.Data/Repositories/FileBlobRepository.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using TeacherWorkout.Domain.FileBlobs;
+using TeacherWorkout.Domain.Models;
+
+namespace TeacherWorkout.Data.Repositories
+{
+    public class FileBlobRepository(TeacherWorkoutContext context) : IFileBlobRepository
+    {
+        private readonly TeacherWorkoutContext _context = context;
+
+        public void Add(FileBlob fileBlob)
+        {
+            _context.FileBlobs.Add(fileBlob);
+            _context.SaveChanges();
+        }
+
+        public FileBlob Find(string id)
+        {
+            return _context.FileBlobs.FirstOrDefault(i => i.Id == id);
+        }
+    }
+}

--- a/TeacherWorkout.Data/TeacherWorkoutContext.cs
+++ b/TeacherWorkout.Data/TeacherWorkoutContext.cs
@@ -10,6 +10,7 @@ namespace TeacherWorkout.Data
         public DbSet<Lesson> Lessons { get; set; }
         public DbSet<Theme> Themes { get; set; }
         public DbSet<Image> Images { get; set; }
+        public DbSet<FileBlob> FileBlobs { get; set; }
 
         public TeacherWorkoutContext(DbContextOptions<TeacherWorkoutContext> options) : base(options)
         {
@@ -42,6 +43,11 @@ namespace TeacherWorkout.Data
                 .HasValueGenerator<StringValueGenerator>();
 
             modelBuilder.Entity<Image>()
+                .Property(l => l.Id)
+                .ValueGeneratedOnAdd()
+                .HasValueGenerator<StringValueGenerator>();
+
+            modelBuilder.Entity<FileBlob>()
                 .Property(l => l.Id)
                 .ValueGeneratedOnAdd()
                 .HasValueGenerator<StringValueGenerator>();

--- a/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
+++ b/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
@@ -1,0 +1,10 @@
+using TeacherWorkout.Domain.Models;
+
+namespace TeacherWorkout.Domain.FileBlobs
+{
+    public interface IFileBlobRepository
+    {
+        void Add(FileBlob fileBlob);
+        FileBlob Find(string id);
+    }
+}

--- a/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
+++ b/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using TeacherWorkout.Domain.Common;
@@ -18,6 +19,7 @@ namespace TeacherWorkout.Domain.FileBlobs
                 Content = input.Content,
                 Mimetype = input.Mimetype,
                 Description = input.FileName,
+                CreatedAt = DateTime.UtcNow
             };
 
             // Validate extension

--- a/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
+++ b/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using TeacherWorkout.Domain.Common;
+using TeacherWorkout.Domain.Models;
+using TeacherWorkout.Domain.Models.Inputs;
+using TeacherWorkout.Domain.Models.Payloads;
+
+namespace TeacherWorkout.Domain.FileBlobs
+{
+    public class SingleUpload(IFileBlobRepository fileBlobRepository) : IOperation<SingleUploadInput, SingleUploadPayload>
+    {
+        private readonly IFileBlobRepository _fileBlobRepository = fileBlobRepository;
+
+        public SingleUploadPayload Execute(SingleUploadInput input)
+        {
+            FileBlob fileBlob = new()
+            {
+                Content = input.Content,
+                Mimetype = input.Mimetype,
+                Description = input.FileName,
+            };
+
+            // Validate extension
+            string extension = System.IO.Path.GetExtension(input.FileName);
+            string[] imageExtensions = [".jpg", ".jpeg", ".png", ".gif"];
+            if (!imageExtensions.Contains(extension.ToLower()))
+            {
+                throw new ValidationException("Invalid image extension");
+            }
+
+            // Validate content type
+            string[] imageContentTypes = ["image/jpeg", "image/png", "image/gif"];
+            if (!imageContentTypes.Contains(fileBlob.Mimetype.ToLower()))
+            {
+                throw new ValidationException("Invalid image content type");
+            }
+
+            _fileBlobRepository.Add(fileBlob);
+
+            return new SingleUploadPayload
+            {
+                FileBlobId = fileBlob.Id
+            };
+        }
+
+        }
+}

--- a/TeacherWorkout.Domain/Models/FileBlob.cs
+++ b/TeacherWorkout.Domain/Models/FileBlob.cs
@@ -1,0 +1,15 @@
+
+using System;
+using TeacherWorkout.Domain.Common;
+
+namespace TeacherWorkout.Domain.Models
+{
+    public class FileBlob : IIdentifiable
+    {
+        public string Id { get; set; }
+        public byte[] Content { get; set; }
+        public string Mimetype { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/TeacherWorkout.Domain/Models/Image.cs
+++ b/TeacherWorkout.Domain/Models/Image.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using TeacherWorkout.Domain.Common;
 
 namespace TeacherWorkout.Domain.Models
@@ -9,5 +10,7 @@ namespace TeacherWorkout.Domain.Models
         public string Description { get; set; }
 
         public string Url { get; set; }
+        
+        public FileBlob FileBlob { get; set; }
     }
 }

--- a/TeacherWorkout.Domain/Models/Inputs/SingleUploadInput.cs
+++ b/TeacherWorkout.Domain/Models/Inputs/SingleUploadInput.cs
@@ -1,0 +1,10 @@
+namespace TeacherWorkout.Domain.Models.Inputs
+{
+    public class SingleUploadInput
+    {
+        public string FileName { get; set; }
+        public string Mimetype { get; set; }
+        public string Encoding { get; set; }
+        public byte[] Content { get; set; }
+    }
+}

--- a/TeacherWorkout.Domain/Models/Payloads/SingleUploadPayload.cs
+++ b/TeacherWorkout.Domain/Models/Payloads/SingleUploadPayload.cs
@@ -1,0 +1,7 @@
+namespace TeacherWorkout.Domain.Models.Payloads
+{
+    public class SingleUploadPayload
+    {
+        public string FileBlobId { get; set; }
+    }
+}


### PR DESCRIPTION
### What does it fix?

Closes #57 

### How has it been tested?

API tested with:
```
curl https://localhost:5001/graphql -k \
        -F operations='{"query": "mutation($file: Upload!) { singleUpload(file: $file) { fileBlobId } }", "variables": { "file": null }}' \
        -F map='{ "0": ["variables.file"] }' \
        -F 0=@room_sm.png
```

Or from Postman:
![Screenshot 2023-11-30 at 15 32 20](https://github.com/code4romania/teacher-workout-backend/assets/516929/e5d00839-06e1-411c-9827-a517e98dd5b3)

Migration tested with:

- Up: `dotnet ef database update --startup-project TeacherWorkout.Api/ --project TeacherWorkout.Data/`
- Down: `dotnet ef database update AddImagesRelation --startup-project TeacherWorkout.Api/ --project TeacherWorkout.Data/`
