### PR TITLE
[57] get and clean images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,3 +336,10 @@ ASALocalRun/
 # Project specific
 postgres_data
 .env
+
+# VSCode
+.vscode
+
+# MacOS
+.DS_Store
+Thumbs.db

--- a/TeacherWorkout.Api/Controllers/FileController.cs
+++ b/TeacherWorkout.Api/Controllers/FileController.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using TeacherWorkout.Data;
+
+namespace TeacherWorkout.Api.Controllers
+{   
+    [Route("file")]
+    [ApiController]
+    public class FileController(TeacherWorkoutContext context) : ControllerBase
+    {
+        private readonly TeacherWorkoutContext _context = context;
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetImage(string id)
+        {
+            var fileBlob = await _context.FileBlobs.FindAsync(id);
+            if (fileBlob == null)
+            {
+                return NotFound();
+            }
+
+            return File(fileBlob.Content, fileBlob.Mimetype);
+        }
+    }
+}

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutMutation.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutMutation.cs
@@ -5,6 +5,7 @@ using GraphQL.Types;
 using GraphQL.Upload.AspNetCore;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using TeacherWorkout.Api.GraphQL.Resolvers;
 using TeacherWorkout.Api.GraphQL.Types.Inputs;
 using TeacherWorkout.Api.GraphQL.Types.Payloads;
@@ -21,7 +22,8 @@ namespace TeacherWorkout.Api.GraphQL
         public TeacherWorkoutMutation(CompleteStep completeStep,
             CreateTheme createTheme,
             UpdateTheme updateTheme,
-            SingleUpload singleUpload)
+            SingleUpload singleUpload,
+            IConfiguration configuration)
         {
             Name = "Mutation";
 
@@ -63,10 +65,11 @@ namespace TeacherWorkout.Api.GraphQL
                 .Resolve(context =>
                 {
                     var file = context.GetArgument<IFormFile>("file");
-
-                    if (file.Length > 5 * 1024 * 1024)
+                    
+                    var maxFileSizeMb = configuration.GetValue("TeacherWorkout:MaxFileSizeMb", 5);
+                    if (file.Length > maxFileSizeMb * 1024 * 1024)
                     {
-                        throw new ValidationException("File size exceeds the limit of 5MB.");
+                        throw new ValidationException($"File size exceeds the limit of {maxFileSizeMb}MB.");
                     }
 
                     using var memoryStream = new MemoryStream();

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutMutation.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutMutation.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using GraphQL;
 using GraphQL.Types;
@@ -62,6 +63,11 @@ namespace TeacherWorkout.Api.GraphQL
                 .Resolve(context =>
                 {
                     var file = context.GetArgument<IFormFile>("file");
+
+                    if (file.Length > 5 * 1024 * 1024)
+                    {
+                        throw new ValidationException("File size exceeds the limit of 5MB.");
+                    }
 
                     using var memoryStream = new MemoryStream();
                     file.CopyTo(memoryStream);

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutMutation.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutMutation.cs
@@ -58,7 +58,7 @@ namespace TeacherWorkout.Api.GraphQL
 
 
             Field<SingleUploadPayloadType>("singleUpload")
-                .Argument<UploadGraphType>(Name = "file")
+                .Argument<NonNullGraphType<UploadGraphType>>(Name = "file")
                 .Resolve(context =>
                 {
                     var file = context.GetArgument<IFormFile>("file");

--- a/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
+++ b/TeacherWorkout.Api/GraphQL/TeacherWorkoutQuery.cs
@@ -1,7 +1,9 @@
+using GraphQL;
 using GraphQL.Types;
 using TeacherWorkout.Api.GraphQL.Types;
 using TeacherWorkout.Api.GraphQL.Utils;
 using TeacherWorkout.Domain.Common;
+using TeacherWorkout.Domain.FileBlobs;
 using TeacherWorkout.Domain.Lessons;
 using TeacherWorkout.Domain.Themes;
 
@@ -12,7 +14,8 @@ namespace TeacherWorkout.Api.GraphQL
         public TeacherWorkoutQuery(GetThemes getThemes, 
             GetLessons getLessons,
             GetLessonStatuses getLessonStatuses,
-            GetStep getStep)
+            GetStep getStep,
+            GetFileBlobs getFileBlobs)
         {
             Name = "Query";
          
@@ -35,6 +38,10 @@ namespace TeacherWorkout.Api.GraphQL
             Field<ListGraphType<NonNullGraphType<LessonStatusType>>>("lessonStatuses")
                 .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<IdGraphType>>>>(Name = "lessonIds", Description = "Id's of leassons")
                 .Resolve(context => getLessonStatuses.Execute(context.ToInput<LessonStatusFilter>()));
+
+            Field<ListGraphType<NonNullGraphType<FileBlobType>>>("recentImageUploads")
+                .Argument<NonNullGraphType<IntGraphType>>("limit", "The number of recent images to return.")
+                .Resolve(context => getFileBlobs.Execute(context.GetArgument<int>("limit")));
         }
     }
 }

--- a/TeacherWorkout.Api/GraphQL/Types/FileBlobType.cs
+++ b/TeacherWorkout.Api/GraphQL/Types/FileBlobType.cs
@@ -1,0 +1,16 @@
+using GraphQL.Types;
+using TeacherWorkout.Domain.Models;
+
+namespace TeacherWorkout.Api.GraphQL.Types
+{
+    public class FileBlobType : ObjectGraphType<FileBlob>
+    {
+        public FileBlobType()
+        {
+            Name = "FileBlob";
+
+            Field(x => x.Id, nullable: false).Description("The unique identifier of the file blob.");
+            Field(x => x.CreatedAt, nullable: false).Description("The creation time of the file blob.");
+        }
+    }
+}

--- a/TeacherWorkout.Api/GraphQL/Types/ImageType.cs
+++ b/TeacherWorkout.Api/GraphQL/Types/ImageType.cs
@@ -9,8 +9,9 @@ namespace TeacherWorkout.Api.GraphQL.Types
         {
             Name = "Image";
             
-            Field(x => x.Url, true).Description("URL to the image.");
+            Field(x => x.Url, true).Description("URL to the image. If null, use FileBlob ID to generate an URL: /file/<fileBlobId>");
             Field(x => x.Description, true).Description("Image description for accessibility.");
+            Field(x => x.FileBlobId, true).Description("Reference to local file. If null, use Url property.");
         }
     }
 }

--- a/TeacherWorkout.Api/GraphQL/Types/Inputs/ThemeCreateInputType.cs
+++ b/TeacherWorkout.Api/GraphQL/Types/Inputs/ThemeCreateInputType.cs
@@ -9,8 +9,11 @@ namespace TeacherWorkout.Api.GraphQL.Types.Inputs
         {
             Name = "ThemeCreateInput";
 
-            Field(x => x.ThumbnailId, type: typeof(IdGraphType));
             Field(x => x.Title);
+            Field(x => x.FileBlobId, true, type: typeof(IdGraphType))
+                .Description("Id of uploaded image blob (precedes and overwrites ThumbnailId)");
+            Field(x => x.ThumbnailId, true, type: typeof(IdGraphType))
+                .Description("Id of existing thumbnail");
         }
     }
 }

--- a/TeacherWorkout.Api/GraphQL/Types/Payloads/SingleUploadPayloadType.cs
+++ b/TeacherWorkout.Api/GraphQL/Types/Payloads/SingleUploadPayloadType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using GraphQL.Types;
+using TeacherWorkout.Domain.Models.Payloads;
+
+namespace TeacherWorkout.Api.GraphQL.Types.Payloads
+{
+    public class SingleUploadPayloadType : ObjectGraphType<SingleUploadPayload>
+    {
+        public SingleUploadPayloadType()
+        {
+            Name = "SingleUploadPayload";
+
+            Field(x => x.FileBlobId).Description("The ID of the created file blob.");
+        }
+    }
+}

--- a/TeacherWorkout.Api/Jobs/Config/DeleteOldFileBlobsConfig.cs
+++ b/TeacherWorkout.Api/Jobs/Config/DeleteOldFileBlobsConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace TeacherWorkout.Api.Jobs.Config
+{
+    public record DeleteOldFileBlobsConfig : RecurringJobConfig
+    {
+        public int DaysInThePast { get; set; }
+    }
+}

--- a/TeacherWorkout.Api/Jobs/Config/RecurringJobConfig.cs
+++ b/TeacherWorkout.Api/Jobs/Config/RecurringJobConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace TeacherWorkout.Api.Jobs.Config
+{
+    public record RecurringJobConfig
+    {
+        public bool IsEnabled { get; set; }
+        public string CronExpression { get; set; }
+    }
+}

--- a/TeacherWorkout.Api/Jobs/DeleteOldFileBlobsJob.cs
+++ b/TeacherWorkout.Api/Jobs/DeleteOldFileBlobsJob.cs
@@ -1,0 +1,20 @@
+using DeUrgenta.RecurringJobs.Jobs.Config;
+using Microsoft.Extensions.Options;
+using TeacherWorkout.Api.Jobs.Interfaces;
+using TeacherWorkout.Domain.FileBlobs;
+
+namespace TeacherWorkout.Api.Jobs
+{
+
+    public class DeleteOldFileBlobsJob(IFileBlobRepository repository, IOptions<DeleteOldFileBlobsConfig> config) : IDeleteOldFileBlobsJob
+    {
+        private readonly IFileBlobRepository _repository = repository;
+        private readonly DeleteOldFileBlobsConfig _config = config.Value;
+        
+        public void Run()
+        {
+            ;
+            _repository.DeleteOldEntries(_config.DaysInThePast);
+        }
+    }
+}

--- a/TeacherWorkout.Api/Jobs/DeleteOldFileBlobsJob.cs
+++ b/TeacherWorkout.Api/Jobs/DeleteOldFileBlobsJob.cs
@@ -1,7 +1,7 @@
-using DeUrgenta.RecurringJobs.Jobs.Config;
 using Microsoft.Extensions.Options;
 using TeacherWorkout.Api.Jobs.Interfaces;
 using TeacherWorkout.Domain.FileBlobs;
+using TeacherWorkout.Api.Jobs.Config;
 
 namespace TeacherWorkout.Api.Jobs
 {

--- a/TeacherWorkout.Api/Jobs/Interfaces/IDeleteOldFileBlobsJob.cs
+++ b/TeacherWorkout.Api/Jobs/Interfaces/IDeleteOldFileBlobsJob.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TeacherWorkout.Api.Jobs.Interfaces
+{
+    public interface IDeleteOldFileBlobsJob
+    {
+        void Run();
+    }
+}

--- a/TeacherWorkout.Api/Startup.cs
+++ b/TeacherWorkout.Api/Startup.cs
@@ -42,10 +42,12 @@ namespace TeacherWorkout.Api
             AddRepositories(services, "TeacherWorkout.Data");
 
             services.AddHttpContextAccessor();
-            services.AddGraphQL(b => b
-                .AddErrorInfoProvider(opt => opt.ExposeExceptionDetails = true)
-                .AddGraphTypes()
-                .AddSystemTextJson());
+            services
+                .AddGraphQLUpload()
+                .AddGraphQL(b => b
+                    .AddErrorInfoProvider(opt => opt.ExposeExceptionDetails = true)
+                    .AddGraphTypes()
+                    .AddSystemTextJson());
 
             services.AddDbContext<TeacherWorkoutContext>(options =>
                 options.UseNpgsql(Configuration.GetConnectionString("TeacherWorkoutContext")));
@@ -67,7 +69,8 @@ namespace TeacherWorkout.Api
 
             app.UseRouting();
 
-            app.UseGraphQL<ISchema>();
+            app.UseGraphQLUpload<ISchema>()
+                .UseGraphQL<ISchema>();
             app.UseGraphQLGraphiQL();
         }
 

--- a/TeacherWorkout.Api/Startup.cs
+++ b/TeacherWorkout.Api/Startup.cs
@@ -90,7 +90,7 @@ namespace TeacherWorkout.Api
 
             var fileBlobRepository = serviceProvider.GetRequiredService<IFileBlobRepository>();
             RecurringJob.AddOrUpdate("DeleteOldFileBlobs",
-                () => fileBlobRepository.DeleteOldEntries(), Cron.Minutely);
+                () => fileBlobRepository.DeleteOldEntries(), Cron.Daily);
         }
 
         private static void AddOperations(IServiceCollection services)

--- a/TeacherWorkout.Api/Startup.cs
+++ b/TeacherWorkout.Api/Startup.cs
@@ -44,6 +44,7 @@ namespace TeacherWorkout.Api
             AddOperations(services);
             AddRepositories(services, "TeacherWorkout.Data");
 
+            services.AddControllers();
             services.AddHttpContextAccessor();
             services
                 .AddGraphQLUpload()
@@ -83,6 +84,7 @@ namespace TeacherWorkout.Api
             }
 
             app.UseRouting();
+            app.UseEndpoints(endpoints => endpoints.MapControllers());
 
             app.UseGraphQLUpload<ISchema>()
                 .UseGraphQL<ISchema>();

--- a/TeacherWorkout.Api/TeacherWorkout.Api.csproj
+++ b/TeacherWorkout.Api/TeacherWorkout.Api.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="GraphQL.Server.All" Version="7.6.0" />
     <PackageReference Include="GraphQL.Server.Ui.Graphiql" Version="7.6.0" />
     <PackageReference Include="GraphQL.Upload.AspNetCore" Version="3.0.3" />
+    <PackageReference Include="Hangfire" Version="1.8.6" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.20.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TeacherWorkout.Api/TeacherWorkout.Api.csproj
+++ b/TeacherWorkout.Api/TeacherWorkout.Api.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="GraphQL.Server.All" Version="7.6.0" />
     <PackageReference Include="GraphQL.Server.Ui.Graphiql" Version="7.6.0" />
+    <PackageReference Include="GraphQL.Upload.AspNetCore" Version="3.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TeacherWorkout.Api/appsettings.json
+++ b/TeacherWorkout.Api/appsettings.json
@@ -12,6 +12,13 @@
     "TeacherWorkoutContext": "Server=postgres;Port=5432;Database=teacher_workout;User Id=docker;Password=docker;"
   },
   "TeacherWorkout": {
-    "MaxFileSizeMb": 5
+    "MaxFileSizeMb": 5,
+    "RecurringJobs": {
+      "DeleteOldFileBlobs": {
+        "IsEnabled": "true",
+        "CronExpression": "0 0 * * *",
+        "DaysInThePast": "1"
+      }
+    }
   }
 }

--- a/TeacherWorkout.Api/appsettings.json
+++ b/TeacherWorkout.Api/appsettings.json
@@ -10,5 +10,8 @@
   "ConnectionStrings": {
     //connection string for release (docker-compose) enviroment
     "TeacherWorkoutContext": "Server=postgres;Port=5432;Database=teacher_workout;User Id=docker;Password=docker;"
+  },
+  "TeacherWorkout": {
+    "MaxFileSizeMb": 5
   }
 }

--- a/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.Designer.cs
+++ b/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherWorkout.Data;
@@ -11,9 +12,11 @@ using TeacherWorkout.Data;
 namespace TeacherWorkout.Data.Migrations
 {
     [DbContext(typeof(TeacherWorkoutContext))]
-    partial class TeacherWorkoutContextModelSnapshot : ModelSnapshot
+    [Migration("20231130130831_AddFileBlobsTable")]
+    partial class AddFileBlobsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.cs
+++ b/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.cs
@@ -23,7 +23,7 @@ namespace TeacherWorkout.Data.Migrations
                     Content = table.Column<byte[]>(type: "bytea", nullable: false),
                     Mimetype = table.Column<string>(type: "text", nullable: false),
                     Description = table.Column<string>(type: "text", nullable: true),
-                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                 },
                 constraints: table =>
                 {

--- a/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.cs
+++ b/TeacherWorkout.Data/Migrations/20231130130831_AddFileBlobsTable.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherWorkout.Data.Migrations
+{
+    public partial class AddFileBlobsTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FileBlobId",
+                table: "Images",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "FileBlobs",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    Content = table.Column<byte[]>(type: "bytea", nullable: false),
+                    Mimetype = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FileBlobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Images_FileBlobId",
+                table: "Images",
+                column: "FileBlobId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Images_FileBlobs_FileBlobId",
+                table: "Images",
+                column: "FileBlobId",
+                principalTable: "FileBlobs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Images_FileBlobs_FileBlobId",
+                table: "Images");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Images_FileBlobId",
+                table: "Images");
+
+            migrationBuilder.DropTable(
+                name: "FileBlobs");
+
+            migrationBuilder.DropColumn(
+                name: "FileBlobId",
+                table: "Images");
+        }
+    }
+}

--- a/TeacherWorkout.Data/Repositories/FileBlobRepository.cs
+++ b/TeacherWorkout.Data/Repositories/FileBlobRepository.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using TeacherWorkout.Domain.FileBlobs;
+using TeacherWorkout.Domain.Models;
+
+namespace TeacherWorkout.Data.Repositories
+{
+    public class FileBlobRepository(TeacherWorkoutContext context) : IFileBlobRepository
+    {
+        private readonly TeacherWorkoutContext _context = context;
+
+        public void Add(FileBlob fileBlob)
+        {
+            _context.FileBlobs.Add(fileBlob);
+            _context.SaveChanges();
+        }
+
+        public FileBlob Find(string id)
+        {
+            return _context.FileBlobs.FirstOrDefault(i => i.Id == id);
+        }
+    }
+}

--- a/TeacherWorkout.Data/Repositories/FileBlobRepository.cs
+++ b/TeacherWorkout.Data/Repositories/FileBlobRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using TeacherWorkout.Domain.FileBlobs;
 using TeacherWorkout.Domain.Models;
@@ -17,6 +18,15 @@ namespace TeacherWorkout.Data.Repositories
         public FileBlob Find(string id)
         {
             return _context.FileBlobs.FirstOrDefault(i => i.Id == id);
+        }
+
+        public List<FileBlob> FindRecent(string[] mimetypes, int? limit)
+        {
+            return _context.FileBlobs
+                .Where(i => mimetypes.Contains(i.Mimetype))
+                .OrderByDescending(i => i.CreatedAt)
+                .Take(limit ?? 5)
+                .ToList();
         }
     }
 }

--- a/TeacherWorkout.Data/Repositories/FileBlobRepository.cs
+++ b/TeacherWorkout.Data/Repositories/FileBlobRepository.cs
@@ -33,9 +33,9 @@ namespace TeacherWorkout.Data.Repositories
                 .ToList();
         }
 
-        public void DeleteOldEntries()
+        public void DeleteOldEntries(int daysInThePast)
         {
-            var cutoffDate = DateTime.Now.AddDays(-1).ToUniversalTime();
+            var cutoffDate = DateTime.Now.AddDays(-daysInThePast).ToUniversalTime();
             var oldEntries = _context.FileBlobs
                 .Where(fb => fb.CreatedAt < cutoffDate && !_context.Images.Any(i => i.FileBlobId == fb.Id));
             _logger.LogInformation("Deleting {EntryCount} old file blobs", oldEntries.Count());

--- a/TeacherWorkout.Data/TeacherWorkoutContext.cs
+++ b/TeacherWorkout.Data/TeacherWorkoutContext.cs
@@ -10,6 +10,7 @@ namespace TeacherWorkout.Data
         public DbSet<Lesson> Lessons { get; set; }
         public DbSet<Theme> Themes { get; set; }
         public DbSet<Image> Images { get; set; }
+        public DbSet<FileBlob> FileBlobs { get; set; }
 
         public TeacherWorkoutContext(DbContextOptions<TeacherWorkoutContext> options) : base(options)
         {
@@ -42,6 +43,11 @@ namespace TeacherWorkout.Data
                 .HasValueGenerator<StringValueGenerator>();
 
             modelBuilder.Entity<Image>()
+                .Property(l => l.Id)
+                .ValueGeneratedOnAdd()
+                .HasValueGenerator<StringValueGenerator>();
+
+            modelBuilder.Entity<FileBlob>()
                 .Property(l => l.Id)
                 .ValueGeneratedOnAdd()
                 .HasValueGenerator<StringValueGenerator>();

--- a/TeacherWorkout.Domain/FileBlobs/GetFileBlobs.cs
+++ b/TeacherWorkout.Domain/FileBlobs/GetFileBlobs.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using TeacherWorkout.Domain.Common;
+using TeacherWorkout.Domain.Models;
+
+namespace TeacherWorkout.Domain.FileBlobs
+{
+    public class GetFileBlobs(IFileBlobRepository repository) : IOperation<int, List<FileBlob>>
+    {
+        private readonly IFileBlobRepository _repository = repository;
+
+        public List<FileBlob> Execute(int limit)
+        {
+            return _repository.FindRecent(ImageUtils.ContentTypes, limit);
+        }
+    }
+}

--- a/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
+++ b/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
@@ -8,6 +8,6 @@ namespace TeacherWorkout.Domain.FileBlobs
         void Add(FileBlob fileBlob);
         FileBlob Find(string id);
         List<FileBlob> FindRecent(string[] mimetypes, int? limit);
-        void DeleteOldEntries();
+        void DeleteOldEntries(int daysInThePast);
     }
 }

--- a/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
+++ b/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using TeacherWorkout.Domain.Models;
 
 namespace TeacherWorkout.Domain.FileBlobs
@@ -6,5 +7,6 @@ namespace TeacherWorkout.Domain.FileBlobs
     {
         void Add(FileBlob fileBlob);
         FileBlob Find(string id);
+        List<FileBlob> FindRecent(string[] mimetypes, int? limit);
     }
 }

--- a/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
+++ b/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
@@ -1,0 +1,10 @@
+using TeacherWorkout.Domain.Models;
+
+namespace TeacherWorkout.Domain.FileBlobs
+{
+    public interface IFileBlobRepository
+    {
+        void Add(FileBlob fileBlob);
+        FileBlob Find(string id);
+    }
+}

--- a/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
+++ b/TeacherWorkout.Domain/FileBlobs/IFileBlobRepository.cs
@@ -8,5 +8,6 @@ namespace TeacherWorkout.Domain.FileBlobs
         void Add(FileBlob fileBlob);
         FileBlob Find(string id);
         List<FileBlob> FindRecent(string[] mimetypes, int? limit);
+        void DeleteOldEntries();
     }
 }

--- a/TeacherWorkout.Domain/FileBlobs/ImageUtils.cs
+++ b/TeacherWorkout.Domain/FileBlobs/ImageUtils.cs
@@ -1,0 +1,8 @@
+namespace TeacherWorkout.Domain.FileBlobs
+{
+    public static class ImageUtils
+    {
+        public static readonly string[] Extensions = [".jpg", ".jpeg", ".png", ".gif"];
+        public static readonly string[] ContentTypes = ["image/jpeg", "image/png", "image/gif"];
+    }
+}

--- a/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
+++ b/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using TeacherWorkout.Domain.Common;
@@ -18,6 +19,7 @@ namespace TeacherWorkout.Domain.FileBlobs
                 Content = input.Content,
                 Mimetype = input.Mimetype,
                 Description = input.FileName,
+                CreatedAt = DateTime.UtcNow
             };
 
             // Validate extension

--- a/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
+++ b/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using TeacherWorkout.Domain.Common;
+using TeacherWorkout.Domain.Models;
+using TeacherWorkout.Domain.Models.Inputs;
+using TeacherWorkout.Domain.Models.Payloads;
+
+namespace TeacherWorkout.Domain.FileBlobs
+{
+    public class SingleUpload(IFileBlobRepository fileBlobRepository) : IOperation<SingleUploadInput, SingleUploadPayload>
+    {
+        private readonly IFileBlobRepository _fileBlobRepository = fileBlobRepository;
+
+        public SingleUploadPayload Execute(SingleUploadInput input)
+        {
+            FileBlob fileBlob = new()
+            {
+                Content = input.Content,
+                Mimetype = input.Mimetype,
+                Description = input.FileName,
+            };
+
+            // Validate extension
+            string extension = System.IO.Path.GetExtension(input.FileName);
+            string[] imageExtensions = [".jpg", ".jpeg", ".png", ".gif"];
+            if (!imageExtensions.Contains(extension.ToLower()))
+            {
+                throw new ValidationException("Invalid image extension");
+            }
+
+            // Validate content type
+            string[] imageContentTypes = ["image/jpeg", "image/png", "image/gif"];
+            if (!imageContentTypes.Contains(fileBlob.Mimetype.ToLower()))
+            {
+                throw new ValidationException("Invalid image content type");
+            }
+
+            _fileBlobRepository.Add(fileBlob);
+
+            return new SingleUploadPayload
+            {
+                FileBlobId = fileBlob.Id
+            };
+        }
+
+        }
+}

--- a/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
+++ b/TeacherWorkout.Domain/FileBlobs/SingleUpload.cs
@@ -17,22 +17,20 @@ namespace TeacherWorkout.Domain.FileBlobs
             FileBlob fileBlob = new()
             {
                 Content = input.Content,
-                Mimetype = input.Mimetype,
+                Mimetype = input.Mimetype.ToLower(),
                 Description = input.FileName,
                 CreatedAt = DateTime.UtcNow
             };
 
             // Validate extension
             string extension = System.IO.Path.GetExtension(input.FileName);
-            string[] imageExtensions = [".jpg", ".jpeg", ".png", ".gif"];
-            if (!imageExtensions.Contains(extension.ToLower()))
+            if (!ImageUtils.Extensions.Contains(extension.ToLower()))
             {
                 throw new ValidationException("Invalid image extension");
             }
 
             // Validate content type
-            string[] imageContentTypes = ["image/jpeg", "image/png", "image/gif"];
-            if (!imageContentTypes.Contains(fileBlob.Mimetype.ToLower()))
+            if (!ImageUtils.ContentTypes.Contains(fileBlob.Mimetype))
             {
                 throw new ValidationException("Invalid image content type");
             }
@@ -44,6 +42,5 @@ namespace TeacherWorkout.Domain.FileBlobs
                 FileBlobId = fileBlob.Id
             };
         }
-
-        }
+    }
 }

--- a/TeacherWorkout.Domain/Models/FileBlob.cs
+++ b/TeacherWorkout.Domain/Models/FileBlob.cs
@@ -1,0 +1,15 @@
+
+using System;
+using TeacherWorkout.Domain.Common;
+
+namespace TeacherWorkout.Domain.Models
+{
+    public class FileBlob : IIdentifiable
+    {
+        public string Id { get; set; }
+        public byte[] Content { get; set; }
+        public string Mimetype { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/TeacherWorkout.Domain/Models/Image.cs
+++ b/TeacherWorkout.Domain/Models/Image.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using TeacherWorkout.Domain.Common;
 
 namespace TeacherWorkout.Domain.Models
@@ -9,5 +10,7 @@ namespace TeacherWorkout.Domain.Models
         public string Description { get; set; }
 
         public string Url { get; set; }
+        
+        public FileBlob FileBlob { get; set; }
     }
 }

--- a/TeacherWorkout.Domain/Models/Image.cs
+++ b/TeacherWorkout.Domain/Models/Image.cs
@@ -11,6 +11,7 @@ namespace TeacherWorkout.Domain.Models
 
         public string Url { get; set; }
         
+        public string FileBlobId { get; set; }
         public FileBlob FileBlob { get; set; }
     }
 }

--- a/TeacherWorkout.Domain/Models/Inputs/SingleUploadInput.cs
+++ b/TeacherWorkout.Domain/Models/Inputs/SingleUploadInput.cs
@@ -1,0 +1,10 @@
+namespace TeacherWorkout.Domain.Models.Inputs
+{
+    public class SingleUploadInput
+    {
+        public string FileName { get; set; }
+        public string Mimetype { get; set; }
+        public string Encoding { get; set; }
+        public byte[] Content { get; set; }
+    }
+}

--- a/TeacherWorkout.Domain/Models/Inputs/ThemeCreateInput.cs
+++ b/TeacherWorkout.Domain/Models/Inputs/ThemeCreateInput.cs
@@ -5,5 +5,6 @@
         public string Title { get; set; }
         
         public string ThumbnailId { get; set; }
+        public string FileBlobId { get; set; }
     }
 }

--- a/TeacherWorkout.Domain/Models/Payloads/SingleUploadPayload.cs
+++ b/TeacherWorkout.Domain/Models/Payloads/SingleUploadPayload.cs
@@ -1,0 +1,7 @@
+namespace TeacherWorkout.Domain.Models.Payloads
+{
+    public class SingleUploadPayload
+    {
+        public string FileBlobId { get; set; }
+    }
+}

--- a/TeacherWorkout.Domain/Themes/CreateTheme.cs
+++ b/TeacherWorkout.Domain/Themes/CreateTheme.cs
@@ -14,7 +14,7 @@ namespace TeacherWorkout.Domain.Themes
     {
         private readonly IThemeRepository _themeRepository = themeRepository;
         private readonly IImageRepository _imageRepository = imageRepository;
-        private readonly IFileBlobRepository _ifileBlobRepository = fileBlobRepository;
+        private readonly IFileBlobRepository _fileBlobRepository = fileBlobRepository;
 
         public ThemeCreatePayload Execute(ThemeCreateInput input)
         {
@@ -25,7 +25,7 @@ namespace TeacherWorkout.Domain.Themes
 
             if (!string.IsNullOrEmpty(input.FileBlobId))
             {
-                var fileBlob = _ifileBlobRepository.Find(input.FileBlobId) ?? throw new ValidationException("FileBlob ID not found");
+                var fileBlob = _fileBlobRepository.Find(input.FileBlobId) ?? throw new ValidationException("FileBlob ID not found");
                 var thumbnail = new Image
                 {
                     Description = fileBlob.Description,

--- a/TeacherWorkout.Domain/Themes/CreateTheme.cs
+++ b/TeacherWorkout.Domain/Themes/CreateTheme.cs
@@ -1,4 +1,6 @@
+using System.ComponentModel.DataAnnotations;
 using TeacherWorkout.Domain.Common;
+using TeacherWorkout.Domain.FileBlobs;
 using TeacherWorkout.Domain.Images;
 using TeacherWorkout.Domain.Models;
 using TeacherWorkout.Domain.Models.Inputs;
@@ -6,28 +8,38 @@ using TeacherWorkout.Domain.Models.Payloads;
 
 namespace TeacherWorkout.Domain.Themes
 {
-    public class CreateTheme : IOperation<ThemeCreateInput, ThemeCreatePayload>
+    public class CreateTheme(IThemeRepository themeRepository,
+        IImageRepository imageRepository,
+        IFileBlobRepository fileBlobRepository) : IOperation<ThemeCreateInput, ThemeCreatePayload>
     {
-        private readonly IThemeRepository _themeRepository;
-        private readonly IImageRepository _imageRepository;
+        private readonly IThemeRepository _themeRepository = themeRepository;
+        private readonly IImageRepository _imageRepository = imageRepository;
+        private readonly IFileBlobRepository _ifileBlobRepository = fileBlobRepository;
 
-        public CreateTheme(IThemeRepository themeRepository,
-            IImageRepository imageRepository)
-        {
-            _themeRepository = themeRepository;
-            _imageRepository = imageRepository;
-        }
-        
         public ThemeCreatePayload Execute(ThemeCreateInput input)
         {
             var theme = new Theme
             {
-                Title = input.Title,
-                Thumbnail = _imageRepository.Find(input.ThumbnailId)
+                Title = input.Title
             };
 
+            if (!string.IsNullOrEmpty(input.FileBlobId))
+            {
+                var fileBlob = _ifileBlobRepository.Find(input.FileBlobId) ?? throw new ValidationException("FileBlob ID not found");
+                var thumbnail = new Image
+                {
+                    Description = fileBlob.Description,
+                    FileBlob = fileBlob
+                };
+                theme.Thumbnail = thumbnail;
+            }
+            else
+            {
+                theme.Thumbnail = _imageRepository.Find(input.ThumbnailId) ?? throw new ValidationException("Thumbnail ID not found");
+            }
+
             _themeRepository.Insert(theme);
-            
+
             return new ThemeCreatePayload
             {
                 Theme = theme

--- a/TeacherWorkout.Migrator/TeacherWorkoutSeeder.cs
+++ b/TeacherWorkout.Migrator/TeacherWorkoutSeeder.cs
@@ -12,8 +12,8 @@ namespace TeacherWorkout.Migrator
     {
         private readonly TeacherWorkoutContext _context;
 
-        private readonly List<Image> _images = new()
-        {
+        private readonly List<Image> _images =
+        [
             new()
             {
                 Id = "1",
@@ -86,13 +86,12 @@ namespace TeacherWorkout.Migrator
             {
                 Id = "11",
                 Description = "Beautiful dog photo",
-                Url =
-                    "https://commons.wikimedia.org/wiki/Category:Quality_images_of_dogs#/media/File:Canis_lupus_PO.jpg"
+                FileBlobId = "FileBlob_1",
             }
-        };
+        ];
 
-        private readonly List<Theme> _themes = new()
-        {
+        private readonly List<Theme> _themes =
+        [
             new()
             {
                 Id = "1",
@@ -159,10 +158,10 @@ namespace TeacherWorkout.Migrator
                 Title = "Accusamus et iusto",
                 ThumbnailId = "11"
             }
-        };
+        ];
 
-        private readonly List<Lesson> _lessons = new()
-        {
+        private readonly List<Lesson> _lessons =
+        [
             new()
             {
                 Id = "1",
@@ -295,7 +294,19 @@ namespace TeacherWorkout.Migrator
                     Unit = DurationUnit.Minutes
                 }
             }
-        };
+        ];
+
+        private readonly List<FileBlob> _fileBlobs =
+        [
+            new()
+            {
+                Id = "FileBlob_1",
+                Content = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="),
+                Mimetype = "image/png",
+                Description = "Tiny image",
+                CreatedAt = DateTime.Now.ToUniversalTime()
+            }
+        ];
 
         public TeacherWorkoutSeeder(TeacherWorkoutContext context)
         {
@@ -315,6 +326,7 @@ namespace TeacherWorkout.Migrator
             await _context.AddRangeAsync(_images);
             await _context.AddRangeAsync(_themes);
             await _context.AddRangeAsync(_lessons);
+            await _context.AddRangeAsync(_fileBlobs);
 
             await _context.SaveChangesAsync();
         }

--- a/TeacherWorkout.Specs/Features/Themes.feature
+++ b/TeacherWorkout.Specs/Features/Themes.feature
@@ -1,15 +1,15 @@
 ﻿Feature: Themes
 	As a user
 	I want to be able to list themes
-	
+
 Scenario: Admin user can create a theme
 	Given Ion is an admin
-	When Ion creates a theme
+	When Ion creates a theme with image
 	Then the theme was created successfully
 
 Scenario: Anonymous user can list themes
 	Given Ion is an admin
 	And Vasile is an anonymous user
-	And Ion creates a theme
+	And Ion creates a theme with image
 	When Vasile requests themes
 	Then Vasile receives the theme

--- a/TeacherWorkout.Specs/Features/Themes.feature.cs
+++ b/TeacherWorkout.Specs/Features/Themes.feature.cs
@@ -102,7 +102,7 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.Given("Ion is an admin", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 7
- testRunner.When("Ion creates a theme", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.When("Ion creates a theme with image", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 8
  testRunner.Then("the theme was created successfully", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -136,7 +136,7 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.And("Vasile is an anonymous user", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 13
- testRunner.And("Ion creates a theme", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("Ion creates a theme with image", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 14
  testRunner.When("Vasile requests themes", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");

--- a/TeacherWorkout.Specs/GraphQL/Mutation/SingleUpload.graphql
+++ b/TeacherWorkout.Specs/GraphQL/Mutation/SingleUpload.graphql
@@ -1,0 +1,5 @@
+mutation SingleUpload($file: Upload!) {
+  singleUpload(file: $file) {
+    fileBlobId
+  }
+}

--- a/TeacherWorkout.Specs/Steps/ThemeStepDefinitions.cs
+++ b/TeacherWorkout.Specs/Steps/ThemeStepDefinitions.cs
@@ -1,25 +1,36 @@
+using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using SpecFlow.Internal.Json;
+using TeacherWorkout.Domain.Models;
 using TeacherWorkout.Specs.Extensions;
 using TechTalk.SpecFlow;
+using Xunit.Abstractions;
 
 namespace TeacherWorkout.Specs.Steps
 {
     [Binding]
-    public class ThemeStepDefinitions
+    public class ThemeStepDefinitions(ScenarioContext scenarioContext)
     {
-        private readonly ScenarioContext _scenarioContext;
+        private readonly ScenarioContext _scenarioContext = scenarioContext;
 
-        public ThemeStepDefinitions(ScenarioContext scenarioContext)
+        [Given(@"Ion creates a theme with image")]
+        [When(@"Ion creates a theme with image")]
+        public async Task GivenIonCreatesAThemeWithImage()
         {
-            _scenarioContext = scenarioContext;
-        }
+            FileBlob imageFile = new()
+            {
+                Id = "FileBlob_1",
+                Content = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="),
+                Mimetype = "image/png",
+                Description = "tiny_image.png",
+                CreatedAt = DateTime.Now.ToUniversalTime()
+            };
+            string uploadJson = await ((TeacherWorkoutApiClient)_scenarioContext["Ion"]).UploadImage(imageFile);
+            string fileBlobId = JObject.Parse(uploadJson)["data"]["singleUpload"]["fileBlobId"].ToString();
 
-        [Given(@"Ion creates a theme")]
-        [When(@"Ion creates a theme")]
-        public async Task GivenIonCreatesATheme()
-        {
-            _scenarioContext["theme-create-response"] = await ((TeacherWorkoutApiClient) _scenarioContext["Ion"]).ThemeCreateAsync();
+            _scenarioContext["theme-create-response"] = await ((TeacherWorkoutApiClient) _scenarioContext["Ion"]).ThemeCreateAsync(fileBlobId);
         }
 
         [When(@"Vasile requests themes")]

--- a/TeacherWorkout.Specs/TeacherWorkoutApiClient.cs
+++ b/TeacherWorkout.Specs/TeacherWorkoutApiClient.cs
@@ -1,7 +1,10 @@
+using System;
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using TeacherWorkout.Domain.Models;
 using TeacherWorkout.Specs.Extensions;
 
 namespace TeacherWorkout.Specs
@@ -15,7 +18,8 @@ namespace TeacherWorkout.Specs
 
         enum Mutations
         {
-            ThemeCreate
+            ThemeCreate,
+            SingleUpload
         }
         
         private readonly HttpClient _client;
@@ -25,18 +29,38 @@ namespace TeacherWorkout.Specs
             _client = client;
         }
 
+        public async Task<string> UploadImage(FileBlob imageFile)
+        {
+
+            var operations = new StringContent(new {query = GraphQL("Mutation", "SingleUpload"), variables = new {file = (string)null}}.ToJson(), Encoding.UTF8, "application/json");
+            var map = new StringContent("{\"0\": [\"variables.file\"]}", Encoding.UTF8, "application/json");
+            var imageBytes = new ByteArrayContent(imageFile.Content);
+            imageBytes.Headers.Add("Content-Type", imageFile.Mimetype);
+
+            var multipartContent = new MultipartFormDataContent("Upload----" + DateTime.Now.ToString(CultureInfo.InvariantCulture))
+            {
+                { operations, "operations" },
+                { map, "map" },
+                { imageBytes, "0", imageFile.Description }
+            };
+            var response = await _client.PostAsync("http://localhost/graphql", multipartContent);
+
+            return await response.Content.ReadAsStringAsync();
+        }
+
         public async Task<string> ThemesAsync()
         {
             return await SendRequest(QueryFor(Queries.Themes), new {});
         }
 
-        public async Task<string> ThemeCreateAsync()
+        public async Task<string> ThemeCreateAsync(string fileBlobId)
         {
             return await SendRequest(MutationFor(Mutations.ThemeCreate), new
             {
                 input = new
                 {
-                    title = "foo"
+                    title = "foo",
+                    fileBlobId,
                 }
             });
         }


### PR DESCRIPTION
### What does it fix?

Closes #57 : additional suggestions
This includes PR #83.

### How has it been tested?

#### Get uploaded image
`GET https://localhost:5001/file/eb8749f3-05a5-4d07-9310-056a2c7ef37d`
_(id taken from `singleUpload` mutation response, see testing on #83)_

#### Create theme with an uploaded image
```
mutation {
  themeCreate(input: { title: "New Theme 4", fileBlobId: "eb8749f3-05a5-4d07-9310-056a2c7ef37d" }) {
    theme {
      id
      title
      thumbnail {
          url,
          fileBlobId
      }
    }
  }
}
```

#### New query to get `recentImageUploads`
```
{
    recentImageUploads(limit: 2) {
        id,
        createdAt
    }
}
```

#### Hangfire cleanup
1. Created new upload with `singleUpload` mutation
2. Manipulated cron frequency in `Startup.cs` to Minutely and parameters of DeleteOldEntries in `FileBlobRepository`, to account for more database entries (can also be done by moving CreatedOn column to a few days ago)
3. Started app and verified orphan entries are removed and dependent entries are not (console logged how many entries were deleted)